### PR TITLE
Fix lints

### DIFF
--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -309,7 +309,7 @@ contract Operations is OperationsFace {
 	}
 
 	modifier only_unratified {
-		require(fork[proposedFork].ratified);
+		require(!fork[proposedFork].ratified);
 		_;
 	}
 

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -277,6 +277,7 @@ contract Operations is OperationsFace {
 
 	function checkProxy(bytes32 _txid) internal when_proxy_confirmed(_txid) returns (uint txSuccess) {
 		var tx = proxy[_txid];
+		// solium-disable-next-line security/no-call-value
 		var success = tx.to.call.value(tx.value).gas(tx.gas)(tx.data);
 		TransactionRelayed(_txid, success);
 		txSuccess = success ? 2 : 1;

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pragma solidity ^0.4.7;
+pragma solidity ^0.4.19;
 
 contract OperationsFace {
 	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas) public returns (uint txSuccess);

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -168,7 +168,7 @@ contract Operations is OperationsFace {
 
 	function setClientOwner(address _newOwner) public only_client_owner {
 		var newClient = clientOwner[msg.sender];
-		clientOwner[msg.sender] = 0;
+		clientOwner[msg.sender] = bytes32(0);
 		clientOwner[_newOwner] = newClient;
 		client[newClient].owner = _newOwner;
 		ClientOwnerChanged(newClient, msg.sender, _newOwner);
@@ -206,7 +206,7 @@ contract Operations is OperationsFace {
 	function resetClientOwner(bytes32 _client, address _newOwner) public only_owner {
 		var old = client[_client].owner;
 		ClientOwnerChanged(_client, old, _newOwner);
-		clientOwner[old] = 0;
+		clientOwner[old] = bytes32(0);
 		clientOwner[_newOwner] = _client;
 		client[_client].owner = _newOwner;
 	}

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -285,26 +285,84 @@ contract Operations is OperationsFace {
 
 	// Modifiers
 
-	modifier only_owner { require(grandOwner == msg.sender); _; }
-	modifier only_client_owner { var newClient = clientOwner[msg.sender]; require(newClient != 0); _; }
-	modifier only_required_client_owner { var newClient = clientOwner[msg.sender]; require(client[newClient].required); _; }
-	modifier only_ratified { require(fork[proposedFork].ratified); _; }
-	modifier only_unratified { require(fork[proposedFork].ratified); _; }
+	modifier only_owner {
+		require(grandOwner == msg.sender);
+		_;
+	}
+
+	modifier only_client_owner {
+		var newClient = clientOwner[msg.sender];
+		require(newClient != 0);
+		_;
+	}
+
+	modifier only_required_client_owner {
+		var newClient = clientOwner[msg.sender];
+		require(client[newClient].required);
+		_;
+	}
+
+	modifier only_ratified {
+		require(fork[proposedFork].ratified);
+		_;
+	}
+
+	modifier only_unratified {
+		require(fork[proposedFork].ratified);
+		_;
+	}
+
 	modifier only_undecided_client_owner {
 		var newClient = clientOwner[msg.sender];
 		require(newClient != 0 && fork[proposedFork].status[newClient] == Status.Undecided);
 		_;
 	}
-	modifier only_when_none_proposed { require(proposedFork == 0); _; }
-	modifier only_when_proposed { require(fork[proposedFork].name != 0); _; }
-	modifier only_when_proxy(bytes32 _txid) { require(proxy[_txid].requiredCount != 0); _; }
-	modifier only_when_no_proxy(bytes32 _txid) { require(proxy[_txid].requiredCount == 0); _; }
-	modifier only_when_proxy_undecided(bytes32 _txid) { require(proxy[_txid].status[clientOwner[msg.sender]] == Status.Undecided); _; }
 
-	modifier when_required(bytes32 _client) { if (client[_client].required) _; }
-	modifier when_have_all_required { if (fork[proposedFork].requiredCount >= clientsRequired) _; }
-	modifier when_changing_required(bytes32 _client, bool _r) { if (client[_client].required != _r) _; }
-	modifier when_proxy_confirmed(bytes32 _txid) { if (proxy[_txid].requiredCount >= clientsRequired) _; }
+	modifier only_when_none_proposed {
+		require(proposedFork == 0);
+		_;
+	}
+
+	modifier only_when_proposed {
+		require(fork[proposedFork].name != 0);
+		_;
+	}
+
+	modifier only_when_proxy(bytes32 _txid) {
+		require(proxy[_txid].requiredCount != 0);
+		_;
+	}
+
+	modifier only_when_no_proxy(bytes32 _txid) {
+		require(proxy[_txid].requiredCount == 0);
+		_;
+	}
+
+	modifier only_when_proxy_undecided(bytes32 _txid) {
+		require(proxy[_txid].status[clientOwner[msg.sender]] == Status.Undecided);
+		_;
+	}
+
+
+	modifier when_required(bytes32 _client) {
+		if (client[_client].required)
+			_;
+	}
+
+	modifier when_have_all_required {
+		if (fork[proposedFork].requiredCount >= clientsRequired)
+			_;
+	}
+
+	modifier when_changing_required(bytes32 _client, bool _r) {
+		if (client[_client].required != _r)
+			_;
+	}
+
+	modifier when_proxy_confirmed(bytes32 _txid) {
+		if (proxy[_txid].requiredCount >= clientsRequired)
+			_;
+	}
 
 	mapping (uint32 => Fork) public fork;
 	mapping (bytes32 => Client) public client;

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -276,9 +276,9 @@ contract Operations is OperationsFace {
 	}
 
 	function checkProxy(bytes32 _txid) internal when_proxy_confirmed(_txid) returns (uint txSuccess) {
-		var tx = proxy[_txid];
+		var txn = proxy[_txid];
 		// solium-disable-next-line security/no-call-value
-		var success = tx.to.call.value(tx.value).gas(tx.gas)(tx.data);
+		var success = txn.to.call.value(txn.value).gas(txn.gas)(txn.data);
 		TransactionRelayed(_txid, success);
 		txSuccess = success ? 2 : 1;
 		delete proxy[_txid];

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -27,12 +27,12 @@ contract OperationsFace {
 	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) public;
 	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) public;
 
-	function isLatest(bytes32 _client, bytes32 _release) public constant returns (bool);
-	function track(bytes32 _client, bytes32 _release) public constant returns (uint8);
-	function latestInTrack(bytes32 _client, uint8 _track) public constant returns (bytes32);
-	function build(bytes32 _client, bytes32 _checksum) public constant returns (bytes32 o_release, bytes32 o_platform);
-	function release(bytes32 _client, bytes32 _release) public constant returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical);
-	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public constant returns (bytes32);
+	function isLatest(bytes32 _client, bytes32 _release) public view returns (bool);
+	function track(bytes32 _client, bytes32 _release) public view returns (uint8);
+	function latestInTrack(bytes32 _client, uint8 _track) public view returns (bytes32);
+	function build(bytes32 _client, bytes32 _checksum) public view returns (bytes32 o_release, bytes32 o_platform);
+	function release(bytes32 _client, bytes32 _release) public view returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical);
+	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public view returns (bytes32);
 }
 
 contract Operations is OperationsFace {
@@ -225,25 +225,25 @@ contract Operations is OperationsFace {
 
 	// Getters
 
-	function isLatest(bytes32 _client, bytes32 _release) public constant returns (bool) {
+	function isLatest(bytes32 _client, bytes32 _release) public view returns (bool) {
 		return latestInTrack(_client, track(_client, _release)) == _release;
 	}
 
-	function track(bytes32 _client, bytes32 _release) public constant returns (uint8) {
+	function track(bytes32 _client, bytes32 _release) public view returns (uint8) {
 		return client[_client].release[_release].track;
 	}
 
-	function latestInTrack(bytes32 _client, uint8 _track) public constant returns (bytes32) {
+	function latestInTrack(bytes32 _client, uint8 _track) public view returns (bytes32) {
 		return client[_client].current[_track];
 	}
 
-	function build(bytes32 _client, bytes32 _checksum) public constant returns (bytes32 o_release, bytes32 o_platform) {
+	function build(bytes32 _client, bytes32 _checksum) public view returns (bytes32 o_release, bytes32 o_platform) {
 		var b = client[_client].build[_checksum];
 		o_release = b.release;
 		o_platform = b.platform;
 	}
 
-	function release(bytes32 _client, bytes32 _release) public constant returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical) {
+	function release(bytes32 _client, bytes32 _release) public view returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical) {
 		var b = client[_client].release[_release];
 		o_forkBlock = b.forkBlock;
 		o_track = b.track;
@@ -251,7 +251,7 @@ contract Operations is OperationsFace {
 		o_critical = b.critical;
 	}
 
-	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public constant returns (bytes32) {
+	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public view returns (bytes32) {
 		return client[_client].release[_release].checksum[_platform];
 	}
 

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -105,15 +105,15 @@ contract Operations is OperationsFace {
 
 	function Operations() public {
 		// Mainnet
-		// fork[0] = Fork("frontier", sha3("frontier"), true, true, 0);
-		// fork[1150000] = Fork("homestead", sha3("homestead"), true, true, 0);
-		// fork[2463000] = Fork("eip150", sha3("eip150"), true, true, 0);
-		// fork[2675000] = Fork("eip155", sha3("eip155"), true, true, 0);
+		// fork[0] = Fork("frontier", keccak256("frontier"), true, true, 0);
+		// fork[1150000] = Fork("homestead", keccak256("homestead"), true, true, 0);
+		// fork[2463000] = Fork("eip150", keccak256("eip150"), true, true, 0);
+		// fork[2675000] = Fork("eip155", keccak256("eip155"), true, true, 0);
 		// latestFork = 2675000;
 
 		// Ropsten
-		fork[0] = Fork("eip150", sha3("eip150"), true, true, 0);
-		fork[10] = Fork("eip155", sha3("eip155"), true, true, 0);
+		fork[0] = Fork("eip150", keccak256("eip150"), true, true, 0);
+		fork[10] = Fork("eip155", keccak256("eip155"), true, true, 0);
 		latestFork = 10;
 
 		client["parity"] = Client(msg.sender, true);

--- a/contracts/Operations.sol
+++ b/contracts/Operations.sol
@@ -285,24 +285,21 @@ contract Operations is OperationsFace {
 
 	// Modifiers
 
-	modifier only_owner { if (grandOwner != msg.sender) throw; _; }
-	modifier only_client_owner { var newClient = clientOwner[msg.sender]; if (newClient == 0) throw; _; }
-	modifier only_required_client_owner { var newClient = clientOwner[msg.sender]; if (!client[newClient].required) throw; _; }
-	modifier only_ratified{ if (!fork[proposedFork].ratified) throw; _; }
-	modifier only_unratified { if (!fork[proposedFork].ratified) throw; _; }
+	modifier only_owner { require(grandOwner == msg.sender); _; }
+	modifier only_client_owner { var newClient = clientOwner[msg.sender]; require(newClient != 0); _; }
+	modifier only_required_client_owner { var newClient = clientOwner[msg.sender]; require(client[newClient].required); _; }
+	modifier only_ratified { require(fork[proposedFork].ratified); _; }
+	modifier only_unratified { require(fork[proposedFork].ratified); _; }
 	modifier only_undecided_client_owner {
 		var newClient = clientOwner[msg.sender];
-		if (newClient == 0)
-			throw;
-		if (fork[proposedFork].status[newClient] != Status.Undecided)
-			throw;
+		require(newClient != 0 && fork[proposedFork].status[newClient] == Status.Undecided);
 		_;
 	}
-	modifier only_when_none_proposed { if (proposedFork != 0) throw; _; }
-	modifier only_when_proposed { if (fork[proposedFork].name == 0) throw; _; }
-	modifier only_when_proxy(bytes32 _txid) { if (proxy[_txid].requiredCount == 0) throw; _; }
-	modifier only_when_no_proxy(bytes32 _txid) { if (proxy[_txid].requiredCount > 0) throw; _; }
-	modifier only_when_proxy_undecided(bytes32 _txid) { if (proxy[_txid].status[clientOwner[msg.sender]] != Status.Undecided) throw; _; }
+	modifier only_when_none_proposed { require(proposedFork == 0); _; }
+	modifier only_when_proposed { require(fork[proposedFork].name != 0); _; }
+	modifier only_when_proxy(bytes32 _txid) { require(proxy[_txid].requiredCount != 0); _; }
+	modifier only_when_no_proxy(bytes32 _txid) { require(proxy[_txid].requiredCount == 0); _; }
+	modifier only_when_proxy_undecided(bytes32 _txid) { require(proxy[_txid].status[clientOwner[msg.sender]] == Status.Undecided); _; }
 
 	modifier when_required(bytes32 _client) { if (client[_client].required) _; }
 	modifier when_have_all_required { if (fork[proposedFork].requiredCount >= clientsRequired) _; }

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -27,14 +27,14 @@ contract OperationsFace {
 	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) public;
 	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) public;
 
-	function isLatest(bytes32 _client, bytes32 _release) public constant returns (bool);
-	function track(bytes32 _client, bytes32 _release) public constant returns (uint8);
-	function latestInTrack(bytes32 _client, uint8 _track) public constant returns (bytes32);
-	function build(bytes32 _client, bytes32 _checksum) public constant returns (bytes32 o_release, bytes32 o_platform);
-	function release(bytes32 _client, bytes32 _release) public constant returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical);
-	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public constant returns (bytes32);
+	function isLatest(bytes32 _client, bytes32 _release) public view returns (bool);
+	function track(bytes32 _client, bytes32 _release) public view returns (uint8);
+	function latestInTrack(bytes32 _client, uint8 _track) public view returns (bytes32);
+	function build(bytes32 _client, bytes32 _checksum) public view returns (bytes32 o_release, bytes32 o_platform);
+	function release(bytes32 _client, bytes32 _release) public view returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical);
+	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public view returns (bytes32);
 
-	function clientOwner(address _owner) public constant returns (bytes32);
+	function clientOwner(address _owner) public view returns (bytes32);
 }
 
 /// Specialise proxy wallet. Owner can send transactions unhindered. Delegates

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -66,7 +66,7 @@ contract OperationsProxy {
 	}
 
 	function send(address _to, uint _value, bytes _data) public payable only_owner {
-		if (!_to.call.value(_value)(_data)) throw;
+		require(_to.call.value(_value)(_data));
 		Sent(_to, _value, _data);
 	}
 
@@ -114,7 +114,7 @@ contract OperationsProxy {
 	}
 
 	function confirm(uint8 _track, bytes32 _hash) public payable only_confirmer_of_track(_track) {
-		if (!address(operations).call.value(msg.value)(waiting[_track][_hash])) throw;
+		require(address(operations).call.value(msg.value)(waiting[_track][_hash]));
 		delete waiting[_track][_hash];
 		RequestConfirmed(_track, _hash);
 	}
@@ -125,7 +125,7 @@ contract OperationsProxy {
 	}
 
 	function relay() internal {
-		if (!address(operations).call.value(msg.value)(msg.data)) throw;
+		require(address(operations).call.value(msg.value)(msg.data));
 	}
 
 	function cleanupRelease(bytes32 _release) public only_confirmer_of_track(trackOfPendingRelease[_release]) {
@@ -136,9 +136,9 @@ contract OperationsProxy {
 		selfdestruct(msg.sender);
 	}
 
-	modifier only_owner { if (msg.sender != owner) throw; _; }
-	modifier only_delegate_of_track(uint8 track) { if (delegate[track] != msg.sender) throw; _; }
-	modifier only_confirmer_of_track(uint8 track) { if (confirmer[track] != msg.sender) throw; _; }
+	modifier only_owner { require(msg.sender == owner); _; }
+	modifier only_delegate_of_track(uint8 track) { require(delegate[track] == msg.sender); _; }
+	modifier only_confirmer_of_track(uint8 track) { require(confirmer[track] == msg.sender); _; }
 
 	address public owner;
 	mapping(uint8 => address) public delegate;

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -86,14 +86,14 @@ contract OperationsProxy {
 		confirmer[_track] = _confirmer;
 	}
 
-	function addRelease(bytes32 _release, uint32, uint8 _track, uint24, bool) public {
+	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) public {
 		if (relayOrConfirm(_track))
 			AddReleaseRelayed(_track, _release);
 		else
 			trackOfPendingRelease[_release] = _track;
 	}
 
-	function addChecksum(bytes32 _release, bytes32 _platform, bytes32) public {
+	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) public {
 		var track = trackOfPendingRelease[_release];
 		if (track == 0)
 			track = operations.track(operations.clientOwner(this), _release);

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -17,30 +17,30 @@
 pragma solidity ^0.4.7;
 
 contract OperationsFace {
-	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas) returns (uint txSuccess);
-	function confirmTransaction(bytes32 _txid) returns (uint txSuccess);
-	function rejectTransaction(bytes32 _txid);
-	function proposeFork(uint32 _number, bytes32 _name, bool _hard, bytes32 _spec);
-	function acceptFork();
-	function rejectFork();
-	function setClientOwner(address _newOwner);
-	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical);
-	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum);
+	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas) public returns (uint txSuccess);
+	function confirmTransaction(bytes32 _txid) public returns (uint txSuccess);
+	function rejectTransaction(bytes32 _txid) public;
+	function proposeFork(uint32 _number, bytes32 _name, bool _hard, bytes32 _spec) public;
+	function acceptFork() public;
+	function rejectFork() public;
+	function setClientOwner(address _newOwner) public;
+	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) public;
+	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) public;
 
-	function isLatest(bytes32 _client, bytes32 _release) constant returns (bool);
-	function track(bytes32 _client, bytes32 _release) constant returns (uint8);
-	function latestInTrack(bytes32 _client, uint8 _track) constant returns (bytes32);
-	function build(bytes32 _client, bytes32 _checksum) constant returns (bytes32 o_release, bytes32 o_platform);
-	function release(bytes32 _client, bytes32 _release) constant returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical);
-	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) constant returns (bytes32);
+	function isLatest(bytes32 _client, bytes32 _release) public constant returns (bool);
+	function track(bytes32 _client, bytes32 _release) public constant returns (uint8);
+	function latestInTrack(bytes32 _client, uint8 _track) public constant returns (bytes32);
+	function build(bytes32 _client, bytes32 _checksum) public constant returns (bytes32 o_release, bytes32 o_platform);
+	function release(bytes32 _client, bytes32 _release) public constant returns (uint32 o_forkBlock, uint8 o_track, uint24 o_semver, bool o_critical);
+	function checksum(bytes32 _client, bytes32 _release, bytes32 _platform) public constant returns (bytes32);
 
-	function clientOwner(address _owner) constant returns (bytes32);
+	function clientOwner(address _owner) public constant returns (bytes32);
 }
 
 /// Specialise proxy wallet. Owner can send transactions unhindered. Delegates
 /// can send only particular transactions to a named Operations contract.
 contract OperationsProxy {
-	function OperationsProxy(address _owner, address _stable, address _beta, address _nightly, address _stableConfirmer, address _betaConfirmer, address _nightlyConfirmer, address _operations) {
+	function OperationsProxy(address _owner, address _stable, address _beta, address _nightly, address _stableConfirmer, address _betaConfirmer, address _nightlyConfirmer, address _operations) public {
 		owner = _owner;
 		delegate[1] = _stable;
 		delegate[2] = _beta;
@@ -61,38 +61,38 @@ contract OperationsProxy {
 	event RequestConfirmed(uint8 indexed track, bytes32 hash);
 	event RequestRejected(uint8 indexed track, bytes32 hash);
 
-	function() only_owner {
+	function() public only_owner {
 		relay();
 	}
 
-	function send(address _to, uint _value, bytes _data) only_owner payable {
+	function send(address _to, uint _value, bytes _data) public payable only_owner {
 		if (!_to.call.value(_value)(_data)) throw;
 		Sent(_to, _value, _data);
 	}
 
-	function setOwner(address _owner) only_owner {
+	function setOwner(address _owner) public only_owner {
 		OwnerChanged(owner, _owner);
 		owner = _owner;
 	}
 
-	function setDelegate(address _delegate, uint8 _track) only_owner {
+	function setDelegate(address _delegate, uint8 _track) public only_owner {
 		DelegateChanged(delegate[_track], _delegate, _track);
 		delegate[_track] = _delegate;
 	}
 
-	function setConfirmer(address _confirmer, uint8 _track) only_owner {
+	function setConfirmer(address _confirmer, uint8 _track) public only_owner {
 		ConfirmerChanged(confirmer[_track], _confirmer, _track);
 		confirmer[_track] = _confirmer;
 	}
 
-	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) {
+	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) public {
 		if (relayOrConfirm(_track))
 			AddReleaseRelayed(_track, _release);
 		else
 			trackOfPendingRelease[_release] = _track;
 	}
 
-	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) {
+	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) public {
 		var track = trackOfPendingRelease[_release];
 		if (track == 0)
 			track = operations.track(operations.clientOwner(this), _release);
@@ -113,13 +113,13 @@ contract OperationsProxy {
 		}
 	}
 
-	function confirm(uint8 _track, bytes32 _hash) only_confirmer_of_track(_track) payable {
+	function confirm(uint8 _track, bytes32 _hash) public payable only_confirmer_of_track(_track) {
 		if (!address(operations).call.value(msg.value)(waiting[_track][_hash])) throw;
 		delete waiting[_track][_hash];
 		RequestConfirmed(_track, _hash);
 	}
 
-	function reject(uint8 _track, bytes32 _hash) only_confirmer_of_track(_track) {
+	function reject(uint8 _track, bytes32 _hash) public only_confirmer_of_track(_track) {
 		delete waiting[_track][_hash];
 		RequestRejected(_track, _hash);
 	}
@@ -128,12 +128,12 @@ contract OperationsProxy {
 		if (!address(operations).call.value(msg.value)(msg.data)) throw;
 	}
 
-	function cleanupRelease(bytes32 _release) only_confirmer_of_track(trackOfPendingRelease[_release]) {
+	function cleanupRelease(bytes32 _release) public only_confirmer_of_track(trackOfPendingRelease[_release]) {
 		delete trackOfPendingRelease[_release];
 	}
 
-	function kill() only_owner {
-		suicide(msg.sender);
+	function kill() public only_owner {
+		selfdestruct(msg.sender);
 	}
 
 	modifier only_owner { if (msg.sender != owner) throw; _; }

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pragma solidity ^0.4.7;
+pragma solidity ^0.4.19;
 
 contract OperationsFace {
 	function proposeTransaction(bytes32 _txid, address _to, bytes _data, uint _value, uint _gas) public returns (uint txSuccess);

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -136,9 +136,20 @@ contract OperationsProxy {
 		selfdestruct(msg.sender);
 	}
 
-	modifier only_owner { require(msg.sender == owner); _; }
-	modifier only_delegate_of_track(uint8 track) { require(delegate[track] == msg.sender); _; }
-	modifier only_confirmer_of_track(uint8 track) { require(confirmer[track] == msg.sender); _; }
+	modifier only_owner {
+		require(msg.sender == owner);
+		_;
+	}
+
+	modifier only_delegate_of_track(uint8 track) {
+		require(delegate[track] == msg.sender);
+		_;
+	}
+
+	modifier only_confirmer_of_track(uint8 track) {
+		require(confirmer[track] == msg.sender);
+		_;
+	}
 
 	address public owner;
 	mapping(uint8 => address) public delegate;

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -102,7 +102,7 @@ contract OperationsProxy {
 
 	function relayOrConfirm(uint8 _track) internal only_delegate_of_track(_track) returns (bool) {
 		if (confirmer[_track] != 0) {
-			var h = sha3(msg.data);
+			var h = keccak256(msg.data);
 			waiting[_track][h] = msg.data;
 			NewRequestWaiting(_track, h);
 			return false;

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -86,14 +86,14 @@ contract OperationsProxy {
 		confirmer[_track] = _confirmer;
 	}
 
-	function addRelease(bytes32 _release, uint32 _forkBlock, uint8 _track, uint24 _semver, bool _critical) public {
+	function addRelease(bytes32 _release, uint32, uint8 _track, uint24, bool) public {
 		if (relayOrConfirm(_track))
 			AddReleaseRelayed(_track, _release);
 		else
 			trackOfPendingRelease[_release] = _track;
 	}
 
-	function addChecksum(bytes32 _release, bytes32 _platform, bytes32 _checksum) public {
+	function addChecksum(bytes32 _release, bytes32 _platform, bytes32) public {
 		var track = trackOfPendingRelease[_release];
 		if (track == 0)
 			track = operations.track(operations.clientOwner(this), _release);

--- a/contracts/OperationsProxy.sol
+++ b/contracts/OperationsProxy.sol
@@ -66,6 +66,7 @@ contract OperationsProxy {
 	}
 
 	function send(address _to, uint _value, bytes _data) public payable only_owner {
+		// solium-disable-next-line security/no-call-value
 		require(_to.call.value(_value)(_data));
 		Sent(_to, _value, _data);
 	}
@@ -114,6 +115,7 @@ contract OperationsProxy {
 	}
 
 	function confirm(uint8 _track, bytes32 _hash) public payable only_confirmer_of_track(_track) {
+		// solium-disable-next-line security/no-call-value
 		require(address(operations).call.value(msg.value)(waiting[_track][_hash]));
 		delete waiting[_track][_hash];
 		RequestConfirmed(_track, _hash);
@@ -125,6 +127,7 @@ contract OperationsProxy {
 	}
 
 	function relay() internal {
+		// solium-disable-next-line security/no-call-value
 		require(address(operations).call.value(msg.value)(msg.data));
 	}
 


### PR DESCRIPTION
This PR is a first pass at cleaning up the `Operations` and `OperationsProxy` contracts. I've fixed all the lints reported by `solium` and all the warnings reported by `solc`. I also fixed a logic bug in the `only_unratified` modifier.

I recommend to review this PR commit-by-commit as I made sure that the commit history is clean and readable.